### PR TITLE
Update onions.txt

### DIFF
--- a/onions.txt
+++ b/onions.txt
@@ -7,8 +7,6 @@ Cl0p - http://ekbgzchl6x2ias37.onion
 Conti - http://continewsnv5otx5kaoje7krkto2qbu3gtqef22mnr7eaxw3y6ncz3ad.onion
 Cuba - http://cuba4mp6ximo2zlo.onion
 DarkRypt - https://darkrypt.io
-DopplePaymer - http://hpoo4dosa3x4ognfxpqcrjwnsigvslm7kv6hvmhh2yqczaxy3j6qnwad.onion
-El Comenta (SynACK) - http://xqkz2rmrqkeqf6sjbrb47jfwnqxcd4o2zvaxxzrpbh2piknms37rw2ad.onion
 Everest - http://ransomocmou6mnbquqz44ewosbkjk3o5qjsl3orawojexfook2j7esad.onion
 Grief - http://griefcameifmv4hfr3auozmovz5yi6m3h3dwbuqw7baomfxoxz4qteid.onion
 Groove - http://ws3dh6av66sjbxxkjpw5ao3wqzmtejnkzheswm4dz5rrwvular7xvkqd.onion
@@ -27,7 +25,6 @@ Prometheus - http://promethw27cbrcot.onion/blog
 Pysa - http://pysa2bitc5ldeyfak4seeruqymqs4sj5wt5qkcq7aoyg4h2acqieywad.onion
 Quantum - http://quantum445bh3gzuyilxdzs5xdepf3b7lkcupswvkryf3n7hgzpxebid.onion
 Ragnar Locker - http://p6o7m73ujalhgkiv.onion
-Ragnarok Leak Site - http://sushlnty2j7qdzy64qnvyb6ajkwg7resd3p6agc2widnawodtcedgjid.onion
 RAMP (Babuk/Payload.bin) - http://wavbeudogz6byhnardd2lkp2jafims3j7tj6k6qnywchn2csngvtffqd.onion
 RansomEXX - http://rnsm777cdsjrsdlbs4v5qoeppu3px6sb2igmh53jzrx7ipcrbjz5b2ad.onion
 REvil (Happy Blog) - http://dnpscnbaix6nkwvystl3yxglz7nteicqrou3t75tpcc5532cztc46qyd.onion


### PR DESCRIPTION
It seems that some of the onion services listed here as online are in fact dead. I whipped up a script to check this: https://gist.github.com/mariavillosa/cb2c1de5cf0a19eb8a68378b1d8ee5ca

Here are the ones that I couldn't load:

```
$ torsocks python3 check_onions.py 
OFFLINE (listed as online: http://3kp6j22pz3zkv76yutctosa6djpj4yib2icvdqxucdaxxedumhqicpad.onion
OFFLINE (listed as online: http://ekbgzchl6x2ias37.onion
OFFLINE (listed as online: http://hpoo4dosa3x4ognfxpqcrjwnsigvslm7kv6hvmhh2yqczaxy3j6qnwad.onion
OFFLINE (listed as online: http://xqkz2rmrqkeqf6sjbrb47jfwnqxcd4o2zvaxxzrpbh2piknms37rw2ad.onion
OFFLINE (listed as online: http://lockbitapt6vx57t3eeqjofwgcglmutr3a35nygvokja5uuccip4ykyd.onion
OFFLINE (listed as online: http://marketojbwagqnwx.onion
OFFLINE (listed as online: http://mountnewsokhwilx.onion
OFFLINE (listed as online: http://promethw27cbrcot.onion/blog
OFFLINE (listed as online: http://p6o7m73ujalhgkiv.onion
OFFLINE (listed as online: http://sushlnty2j7qdzy64qnvyb6ajkwg7resd3p6agc2widnawodtcedgjid.onion
```